### PR TITLE
Update Pythons, workflows for Poetry 1.2.0 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
         run: poetry install --no-root
 
       - name: Install poetry-dotenv-plugin
-        run: poetry plugin add "$GITHUB_WORKSPACE"
+        run: poetry self add "$GITHUB_WORKSPACE"
 
       - name: Run system tests
         run: tests/test_system.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, MacOS]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, MacOS]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,9 @@ jobs:
       matrix:
         os: [Ubuntu, MacOS]
         python-version: [3.6, 3.7, 3.8, 3.9]
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v2
 
@@ -28,19 +31,15 @@ jobs:
 
       - name: Get full Python version
         id: full-python-version
-        shell: bash
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
       - name: Install poetry
-        shell: bash
         run: curl -sL https://raw.githubusercontent.com/python-poetry/poetry/1.2.0a1/install-poetry.py | python - -y --preview
 
       - name: Update PATH
-        shell: bash
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Configure poetry
-        shell: bash
         run: poetry config virtualenvs.in-project true
 
       - name: Set up cache
@@ -52,17 +51,13 @@ jobs:
 
       - name: Ensure cache is healthy
         if: steps.cache.outputs.cache-hit == 'true'
-        shell: bash
         run: timeout 10s poetry run pip --version || rm -rf .venv
 
       - name: Install dependencies
-        shell: bash
         run: poetry install --no-root
 
       - name: Install poetry-dotenv-plugin
-        shell: bash
         run: poetry plugin add "$GITHUB_WORKSPACE"
 
       - name: Run system tests
-        shell: bash
         run: tests/test_system.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
         run: echo ::set-output name=version::$(python -c "import sys; print('-'.join(str(v) for v in sys.version_info))")
 
       - name: Install poetry
-        run: curl -sL https://raw.githubusercontent.com/python-poetry/poetry/1.2.0a1/install-poetry.py | python - -y --preview
+        run: curl -sL curl -sL https://install.python-poetry.org | python - -y
 
       - name: Update PATH
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+# Based on
+# https://github.com/python-poetry/poetry/blob/a0cc7d6b9ea9b59203ac01e4ac641643dc7c9c7a/.github/workflows/release.yml
+
+name: Release
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+
+      - name: Install Poetry
+        run: curl -sL https://raw.githubusercontent.com/python-poetry/poetry/1.2.0/install-poetry.py | python - -y
+
+      - name: Update PATH
+        run: echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Build project for distribution
+        run: poetry build
+
+      - name: Check Version
+        id: check-version
+        run: |
+          [[ "$(poetry version --short)" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] \
+            || echo ::set-output name=prerelease::true
+
+      - name: Create Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "dist/*"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: false
+          prerelease: steps.check-version.outputs.prerelease == 'true'
+
+      - name: Publish to PyPI
+        env:
+          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+        run: poetry publish

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Initial implementation based on the event handler application plugin example in 
 ## Install
 
 ```sh
-poetry plugin add poetry-dotenv-plugin
+poetry self add poetry-dotenv-plugin
 ```
 
 ### Coming from Pipenv

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A [Poetry](https://python-poetry.org/) plugin that automatically loads environment variables from `.env` files into the environment before poetry commands are run.
 
-Supports Python 3.6+
+Supports Python 3.7+
 
 ```sh
 $ cat .env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-dotenv-plugin"
-version = "0.1.0a2"
+version = "0.1.0"
 description = "A Poetry plugin to automatically load environment variables from .env files"
 authors = ["Michael Peteuil <michael.peteuil@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
+python = ">=3.7,<4"
 poetry = ">=1.2.0a1"
 python-dotenv = ">=0.10.0"
 


### PR DESCRIPTION
The updates here are a bit of cleanup required for the 1.2.0 Poetry release, which is the first official release to [support plugins](https://python-poetry.org/blog/announcing-poetry-1.2.0/#plugin-support) such as this one. The first such support came early on in the 1.2.0 development cycle ([in their 1.2.0a1 release](https://python-poetry.org/history/#120a1---2021-05-21)).

Other updates include adding a release workflow, dropping 3.6 support since [Poetry also dropped 3.6](https://github.com/python-poetry/poetry/pull/5055) support (due to [it's end-of-life on December 23, 2021](https://peps.python.org/pep-0494/)), and just removing the pre-release status (i.e. dropping alpha).