### PR TITLE
Test that it works on Python 3.11 too

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, MacOS]
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
This will include 3.11 support in the testing matrix. Right now the `setup-python` action only supports `3.11-dev` as an option, which still resolves to `3.11.0-rc.2` at the moment. This will have to be switched over to 3.11 when it's supported.