### PR TITLE
Build on 3.11 official and 3.12 dev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [Ubuntu, MacOS]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11-dev"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12-dev"]
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
The python setup action now supports both 3.11 stable and 3.12 development release (alpha, etc.). We should test on everything that Poetry core supports.