### PR TITLE
Add option not to override existing env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ Pipenv env var | Poetry env var
 -------------- | ----------------------
 PIPENV_DOTENV_LOCATION | POETRY_DOTENV_LOCATION
 PIPENV_DONT_LOAD_ENV | POETRY_DONT_LOAD_ENV
+
+### Overriding existing environment variables
+
+By default, this plugin will override existing environment variables. This is because this plugin was built to make onboarding for users coming from `pipenv` as seamless as possible. If you want to prevent existing environment variables from being overridden, you can set the `POETRY_DOTENV_DONT_OVERRIDE` environment variable to `true`.[^1]
+
+[^1]: See [#16](https://github.com/mpeteuil/poetry-dotenv-plugin/pull/16) for background.

--- a/poetry_dotenv_plugin/dotenv_plugin.py
+++ b/poetry_dotenv_plugin/dotenv_plugin.py
@@ -29,4 +29,9 @@ class DotenvPlugin(ApplicationPlugin):
             io.write_line("<debug>Loading environment variables.</debug>")
 
         path = POETRY_DOTENV_LOCATION or dotenv.find_dotenv(usecwd=True)
-        dotenv.load_dotenv(dotenv_path=path, override=True)
+        POETRY_DOTENV_DONT_OVERRIDE = os.environ.get("POETRY_DOTENV_DONT_OVERRIDE", "")
+        DOTENV_OVERRIDE = not POETRY_DOTENV_DONT_OVERRIDE.lower() in (
+            "true",
+            "1",
+        )
+        dotenv.load_dotenv(dotenv_path=path, override=DOTENV_OVERRIDE)

--- a/tests/test_system.sh
+++ b/tests/test_system.sh
@@ -56,6 +56,46 @@ function test_end_to_end_system_with_dotenv_location_override() {
   fi
 }
 
+function test_end_to_end_system_with_default_env_overrides() {
+  # Setup
+  local expected
+  expected='foo'
+  create_dotenv_file
+
+  local output
+  output=$(export MY_ENV_VAR='bar' && poetry run python -c "import os; print(os.environ['MY_ENV_VAR'])")
+
+  # Cleanup
+  delete_dotenv_file
+
+  if [ "$expected" = "$output" ]; then
+    printf "test_end_to_end_system_with_default_env_overrides: PASSED\n"
+  else
+    printf "Expected '$expected', but got '%s'.\n" "$output"
+    exit 1
+  fi
+}
+
+function test_end_to_end_system_without_env_overrides() {
+  # Setup
+  local expected
+  expected='bar'
+  create_dotenv_file
+
+  local output
+  output=$(export MY_ENV_VAR='bar' POETRY_DOTENV_DONT_OVERRIDE=true && poetry run python -c "import os; print(os.environ['MY_ENV_VAR'])")
+
+  # Cleanup
+  delete_dotenv_file
+
+  if [ "$expected" = "$output" ]; then
+    printf "test_end_to_end_system_without_env_overrides: PASSED\n"
+  else
+    printf "Expected '$expected', but got '%s'.\n" "$output"
+    exit 1
+  fi
+}
+
 function test_end_to_end_system_without_loading_dotenv_file() {
   # Setup
   local expected
@@ -78,4 +118,6 @@ function test_end_to_end_system_without_loading_dotenv_file() {
 
 test_end_to_end_system_with_default_dotenv_file
 test_end_to_end_system_with_dotenv_location_override
+test_end_to_end_system_with_default_env_overrides
+test_end_to_end_system_without_env_overrides
 test_end_to_end_system_without_loading_dotenv_file


### PR DESCRIPTION
The reason the default behavior of this plugin is to override existing environment variables is because [it has origins](https://github.com/python-poetry/poetry/issues/337) during the time when there were a lot of users migrating away from [Pipenv](https://github.com/pypa/pipenv), many switching to Poetry. [Pipenv had built-in `.env` loading](https://pipenv.pypa.io/en/latest/shell/#automatic-loading-of-env) which [did override by default (and still does)](https://github.com/pypa/pipenv/blob/98bdb5f8b2f08a435a825915d7d7d215a7aaec19/pipenv/utils/environment.py#L37). In order to support the many people coming from `pipenv` the goal was to make the fewest changes from that toolset possible in regards to `.env` loading. That is also why there are other some [analogous environment variables between this project and `pipenv` with a section about them in the README](https://github.com/mpeteuil/poetry-dotenv-plugin#coming-from-pipenv).

If you're coming from vanilla `python-dotenv` then this is unexpected. That needs to be reconciled with the expectations of anyone coming from `pipenv`. Here we add a system environment variable—`POETRY_DOTENV_DONT_OVERRIDE`. I think it should solve most cases. This is because most users who want it to [behave like `python-dotenv`'s defaults](https://github.com/theskumar/python-dotenv#getting-started) probably want that everywhere and the same for anyone who wants it to behave like `pipenv`.

This resolves #14 