### PR TITLE
Use Python 3.11 / Poetry 1.5.1 in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install Poetry
-        run: curl -sL https://raw.githubusercontent.com/python-poetry/poetry/1.2.0/install-poetry.py | python - -y
+        run: curl -sL https://raw.githubusercontent.com/python-poetry/poetry/1.5.1/install-poetry.py | python - -y
 
       - name: Update PATH
         run: echo "$HOME/.local/bin" >> $GITHUB_PATH


### PR DESCRIPTION
This just updates the versions used in the release workflow. Pretty minimal difference.